### PR TITLE
Add risk classification notebook with Poisson regression model

### DIFF
--- a/notebook/risk-classification.ipynb
+++ b/notebook/risk-classification.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Classifying Risks Leveraging Poisson Regression Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- The frequency of claim is the target variable here.\n",
+    "- Minimal risk rating factor that can be leveraged to classify risks into frequency bands\n",
+    "- Make it an inference service that can be used deployed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Preparing the Dataset \n",
+    "\n",
+    "- The frequency from the claims dataset to be aggregated\n",
+    "- Joined onto the rating factors; rating factors double checked for duplicates\n",
+    "- Rating factor records without a claims frequency , assigned a value of 0. This is indicates the a claim was not recorded by that policy holder\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rating_factors = pd.read_csv('../data/input/exp/Motor vehicle insurance data.csv', delimiter=\";\")\n",
+    "claims =  pd.read_csv('../data/input/exp/sample type claim.csv', delimiter=';')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>claims_frequency</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>5255.000000</td>\n",
+       "      <td>5255.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>27383.924263</td>\n",
+       "      <td>1.401713</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>15437.708864</td>\n",
+       "      <td>0.750711</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>28.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>14287.500000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>27905.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>40515.000000</td>\n",
+       "      <td>2.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>53459.000000</td>\n",
+       "      <td>9.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 ID  claims_frequency\n",
+       "count   5255.000000       5255.000000\n",
+       "mean   27383.924263          1.401713\n",
+       "std    15437.708864          0.750711\n",
+       "min       28.000000          1.000000\n",
+       "25%    14287.500000          1.000000\n",
+       "50%    27905.000000          1.000000\n",
+       "75%    40515.000000          2.000000\n",
+       "max    53459.000000          9.000000"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "claims_frequency  = (\n",
+    "    claims\n",
+    "    .groupby('ID')\n",
+    "    .agg({'Claims_type': 'count'})\n",
+    "    .rename(columns={'Claims_type': 'claims_frequency'})\n",
+    "    .reset_index()\n",
+    ")\n",
+    "claims_frequency.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "claims_frequency\n",
+       "1.0    7791\n",
+       "2.0    2102\n",
+       "3.0     588\n",
+       "4.0     139\n",
+       "5.0      45\n",
+       "6.0      14\n",
+       "9.0       5\n",
+       "7.0       2\n",
+       "8.0       1\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset = (\n",
+    "    pd.merge(left=rating_factors,\n",
+    "             right=claims_frequency,\n",
+    "             on='ID',\n",
+    "             how='left'))\n",
+    "dataset.claims_frequency.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- Introduced a new Jupyter notebook for classifying risks using a Poisson regression model.
- Included markdown explanations outlining the target variable and minimal risk rating factors.
- Added code for loading datasets related to motor vehicle insurance and claims frequency analysis.
- Implemented initial data aggregation to calculate claims frequency by ID.