### PR TITLE
refactor: enhance severity modelling notebook with improved documenta…

### DIFF
--- a/notebook/freq_sev/severity.ipynb
+++ b/notebook/freq_sev/severity.ipynb
@@ -9,52 +9,100 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "This covers the second part of the modelling. The target variable is the loss.",
-   "id": "50d7bc46172c2635"
+   "source": [
+    "## Overview\n",
+    "\n",
+    "- This notebook covers the second part of the frequency-severity modelling approach, focusing on predicting claim amounts (severity)\n",
+    "- The target variable is `Cost_claims_year` which represents the total claim amount per policy per year\n",
+    "- We use a Gamma GLM since claim amounts are strictly positive and right-skewed\n",
+    "- Remember that technically `premium = frequency * severity`"
+   ],
+   "id": "fa71fa938ca06cc3"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "## 001: Create the dataset and split dataset",
-   "id": "726fe62960d04380"
+   "source": "## Setup",
+   "id": "1c2e5d5bbadeb438"
   },
   {
    "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
-    "from model import feature\n",
-    "from src.model.dataset import Dataset\n",
-    "\n",
-    "insurance_initiation_variables_path = \"../../data/input/exp/Insurance_Initiation_Variables.csv\"\n",
-    "claims_variables_path = \"../../data/input/exp/sample_type_claim.csv\"\n",
-    "\n",
-    "claim_grouping_columns = ['ID', 'Cost_claims_year']\n",
-    "claim_aggregation_column = 'Cost_claims_by_type'\n",
-    "merging_columns = ['ID', 'Cost_claims_year']\n",
-    "\n",
-    "dataset = (Dataset(data_path=insurance_initiation_variables_path,\n",
-    "                   claims_path=claims_variables_path)\n",
-    "           .group_claims(grouping_columns=claim_grouping_columns, aggregation_column=claim_aggregation_column)\n",
-    "           .create_dataset(merge_columns=merging_columns)\n",
-    "           )\n",
-    "trainset, testset = dataset.split_dataset(test_ratio=0.2, to_shuffle=False)"
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.linear_model import GammaRegressor\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import mean_absolute_error,mean_squared_error"
    ],
-   "id": "e201eb1fea07d65a"
+   "id": "aa953af9f2631a4c",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "## 002: Engineer relevant features",
+   "source": [
+    "## 1. Prepare Dataset\n",
+    "\n",
+    "| Step | Action |\n",
+    "|------|--------|\n",
+    "| Load | Read insurance and claims data |\n",
+    "| Aggregate | Count claims by (ID, year) |\n",
+    "| Merge | Left join on (ID, year) |\n",
+    "| Fill | NaN → 0 for no claims |\n",
+    "| Split | 80/20 train-test split |"
+   ],
+   "id": "c79edd9133597c52"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### 1.1 Load and merge data",
+   "id": "538261d2c0ce99b4"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "insurance = pd.read_csv('../../data/input/Motor_vehicle_insurance_data.csv', delimiter=\";\")\n",
+    "claims =  pd.read_csv('../../data/input/sample_type_claim.csv', delimiter=';')\n",
+    "\n",
+    "claims_frequency  = (\n",
+    "    claims\n",
+    "    .groupby(['ID', 'Cost_claims_year'])\n",
+    "    .agg({'Cost_claims_by_type': 'count'})\n",
+    "    .rename(columns={'Cost_claims_by_type': 'claims_frequency'})\n",
+    "    .reset_index()\n",
+    ")\n",
+    "dataset = (\n",
+    "    pd\n",
+    "    .merge(\n",
+    "        left=insurance,\n",
+    "        right=claims_frequency,\n",
+    "        how='left',\n",
+    "        on=['ID', 'Cost_claims_year']\n",
+    "    )\n",
+    "    .fillna(value={'claims_frequency':0})\n",
+    ")\n",
+    "trainset, testset = train_test_split(dataset, test_size=0.2, random_state=42, shuffle=True)"
+   ],
+   "id": "e201eb1fea07d65a",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## 2. Engineer Relevant Features",
    "id": "31989011cb7b791e"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "from model.feature import main as feature_main\n",
-    "\n",
+    "from src.model.freq_sev.feature import  main as feature_main\n",
     "features_trainset = feature_main(trainset)\n",
     "features_testset = feature_main(testset)"
    ],
@@ -66,34 +114,35 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "## 003: Severity modelling\n",
+    "## 3. Analyse Target Variable [on training data]\n",
     "\n",
-    "The response variable is the number of claims dubbed `Cost_claims_year` in the dataset. The first step would be to understand the distribution of the response variable"
+    "The response variable is the amount of claims dubbed `Cost_claims_year` in the dataset. Unlike frequency modelling where we predict count of claims, severity modelling predicts the monetary amount.\n",
+    "\n",
+    "Key considerations for severity modelling:\n",
+    "1. Distribution of the response variable (typically right-skewed)\n",
+    "2. Only policies with claims (severity > 0) are used for training\n",
+    "3. Gamma distribution is appropriate for positive continuous outcomes"
    ],
-   "id": "89e0cef2c1ca92dd"
+   "id": "73e90194e8dbe187"
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-10-20T20:18:12.899884Z",
-     "start_time": "2025-10-20T20:18:12.282383Z"
-    }
-   },
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### 3.1 Distribution of claim severity",
+   "id": "fdde5fe4becc54db"
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
     "fig, (ax0, ax1) = plt.subplots(ncols=2, figsize=(15, 5))\n",
     "ax0.set_title('Loss Distribution')\n",
     "_ = features_trainset['Cost_claims_year'].hist(bins=40, log=True, ax=ax0)\n",
     "\n",
     "p2_5, p97_5 = np.percentile(features_trainset['Cost_claims_year'], [2.5, 97.5])\n",
-    "middle_95 = features_trainset['Cost_claims_year'][(features_trainset['Cost_claims_year'] >= p2_5) &\n",
-    "                                                   (features_trainset['Cost_claims_year'] <= p97_5)]\n",
+    "middle_95 = features_trainset['Cost_claims_year'][(features_trainset['Cost_claims_year'] >= p2_5) &                                         (features_trainset['Cost_claims_year'] <= p97_5)]\n",
     "ax1.set_title('Middle-95% Loss Distribution (2.5%-97.5%)')\n",
     "_ = middle_95.hist(bins=40, log=False, ax=ax1)\n",
-    "\n",
     "print(\n",
     "    \"Average loss distribution: {}\".format(\n",
     "        np.average(features_trainset['Cost_claims_year'])\n",
@@ -108,20 +157,36 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "Then we follow the steps have below to fit the model\n",
-    "- Define evaluation metrics\n",
-    "- Filter for policies with claims severity greater than 0 because gamma distribution support positive values greater than 0\n",
-    "- We fit a dummy model and a gamma model and compare both\n",
-    "- We review the observed vs predicted for the test set"
+    "- The distribution is heavily right-skewed with a long tail of high-value claims\n",
+    "- The middle 95% shows the bulk of claims are concentrated at lower values\n",
+    "- This confirms the Gamma distribution is an appropriate choice for modelling"
    ],
-   "id": "47f2d7d85ee44390"
+   "id": "eb5910ddfab282f8"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## 4. Model Development\n",
+    "\n",
+    "| Model | Type | Description |\n",
+    "|-------|------|-------------|\n",
+    "| Baseline | DummyRegressor | Predict mean |\n",
+    "| Gamma | GLM | Severity-specific, handles positive skewed data |"
+   ],
+   "id": "a9d55bc729bb770c"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### 4.1 Define training variables and evaluation metrics",
+   "id": "c56ac8af5c11bf3c"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "training_variables = ['Car_age_years', 'Type_risk', 'Area', 'Value_vehicle', 'Distribution_channel',\n",
-    "                      'Cylinder_capacity']\n",
+    "train_variables = ['Car_age_years', 'Type_risk', 'Area', 'Value_vehicle', 'Distribution_channel','Cylinder_capacity']\n",
     "target = ['Cost_claims_year']"
    ],
    "id": "1b9bf2db0e0e937d",
@@ -132,28 +197,32 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "from sklearn.metrics import mean_absolute_error,mean_poisson_deviance,mean_squared_error\n",
-    "\n",
-    "def model_evaluation_metrics(estimator, df_test, target_variable=target, training_variables=training_variables):\n",
-    "    \"\"\"Score an estimator on the test set.\"\"\"\n",
+    "def model_evaluation_metrics(estimator, df_test, target_variable, training_variables):\n",
     "    y_pred = estimator.predict(df_test[training_variables])\n",
-    "\n",
+    "    mse = mean_squared_error(df_test[target_variable], y_pred)\n",
+    "    mae = mean_absolute_error(df_test[target_variable], y_pred)\n",
     "    print(\n",
     "        \"MSE: %.3f\"\n",
-    "        % mean_squared_error(\n",
-    "            df_test[target], y_pred,\n",
-    "        )\n",
+    "        % mse\n",
     "    )\n",
     "    print(\n",
     "        \"MAE: %.3f\"\n",
-    "        % mean_absolute_error(\n",
-    "            df_test[target], y_pred\n",
-    "        )\n",
-    "    )\n"
+    "        % mae\n",
+    "    )"
    ],
    "id": "e1d39595f4f25981",
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### 4.2 Filter for policies with claims\n",
+    "\n",
+    "Because we are fitting a Gamma regressor, we filter out policies where no claims have been made. The Gamma distribution only supports strictly positive values (y > 0)."
+   ],
+   "id": "70d7ebb297a09500"
   },
   {
    "metadata": {},
@@ -171,7 +240,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "#### Model 1 - Baseline Model, Just predicting the mean",
+   "source": "### 4.3 Model 1: Baseline (Mean Prediction)",
    "id": "12622c0cc458afdd"
   },
   {
@@ -179,9 +248,10 @@
    "cell_type": "code",
    "source": [
     "from sklearn.dummy import DummyRegressor\n",
-    "\n",
-    "dummy = DummyRegressor()\n",
-    "dummy_regressor = dummy.fit(updated_features_trainset[training_variables], updated_features_trainset[target])"
+    "dummy = DummyRegressor(strategy=\"mean\")\n",
+    "dummy_regressor = dummy.fit(updated_features_trainset[train_variables], updated_features_trainset[target])\n",
+    "print(\"Constant mean severity evaluation:\")\n",
+    "model_evaluation_metrics(estimator=dummy_regressor, df_test=updated_features_testset, target_variable=target, training_variables=train_variables)"
    ],
    "id": "3e25d56e86c1b94f",
    "outputs": [],
@@ -190,34 +260,50 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "#### Model 2: Gamma Regressor",
+   "source": "### 4.4 Model 2: Gamma Regressor",
    "id": "b36e6ac934cfdcd6"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "from sklearn.linear_model import GammaRegressor\n",
-    "gamma = GammaRegressor(alpha=10, solver=\"newton-cholesky\")\n",
-    "gamma_regressor =  gamma.fit(updated_features_trainset[training_variables], updated_features_trainset[target].values.ravel())"
+    "gamma = GammaRegressor(alpha=10,\n",
+    "                       solver=\"newton-cholesky\",\n",
+    "                       max_iter=10000, )\n",
+    "gamma_regressor =  gamma.fit(updated_features_trainset[train_variables], updated_features_trainset[target].values.ravel())\n",
+    "print(\"Gamma regression evaluation:\")\n",
+    "model_evaluation_metrics(estimator=gamma_regressor, df_test=updated_features_testset, target_variable=target, training_variables=train_variables)"
    ],
-   "id": "c5e6049905999105",
+   "id": "ded53485013050bb",
    "outputs": [],
    "execution_count": null
   },
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "## 004: Severity Modelling Evaluation",
+   "source": [
+    "## 5. Model Evaluation\n",
+    "\n",
+    "| Check | Purpose |\n",
+    "|-------|---------|\n",
+    "| Metrics comparison | Compare MSE/MAE across models |\n",
+    "| Observed vs Predicted | Visual calibration check |"
+   ],
    "id": "4afbd562ba268b50"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### 5.1 Model comparison",
+   "id": "1437c3bf01eb6ecb"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
     "for idx, model in enumerate([dummy_regressor, gamma_regressor]):\n",
-    "    print(f\"Now evaluating model {str(model)}\")\n",
-    "    print(f\"Model metrics : {model_evaluation_metrics(estimator=model, df_test=updated_features_testset, target_variable=target,)}\")\n",
+    "    print(f\"Now evaluating model {model.__class__.__name__}\")\n",
+    "    model_evaluation_metrics(estimator=model, df_test=updated_features_testset, target_variable=target, training_variables=train_variables)\n",
     "    print(\"-------------\")"
    ],
    "id": "9641f74521856283",
@@ -225,12 +311,13 @@
    "execution_count": null
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-10-20T19:57:36.948137Z",
-     "start_time": "2025-10-20T19:57:36.931947Z"
-    }
-   },
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### 5.2 Observed vs Predicted visualization",
+   "id": "8770af43f5d35d7e"
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "def plot_obs_pred(\n",
@@ -243,23 +330,6 @@
     "    ax=None,\n",
     "    fill_legend=False,\n",
     "):\n",
-    "    \"\"\"Plot observed and predicted - aggregated per feature level.\n",
-    "\n",
-    "    Parameters\n",
-    "    ----------\n",
-    "    df : DataFrame\n",
-    "        input data\n",
-    "    feature: str\n",
-    "        a column name of df for the feature to be plotted\n",
-    "    weight : str\n",
-    "        column name of df with the values of weights or exposure\n",
-    "    observed : str\n",
-    "        a column name of df with the observed target\n",
-    "    predicted : DataFrame\n",
-    "        a dataframe, with the same index as df, with the predicted target\n",
-    "    fill_legend : bool, default=False\n",
-    "        whether to show fill_between legend\n",
-    "    \"\"\"\n",
     "    # aggregate observed and predicted variables by feature level\n",
     "    df_ = df.loc[:, [feature]].copy()\n",
     "    df_[\"observed\"] = df[observed] #* df[weight]\n",
@@ -270,7 +340,6 @@
     "        .assign(observed=lambda x: x[\"observed\"])\n",
     "        .assign(predicted=lambda x: x[\"predicted\"])\n",
     "    )\n",
-    "\n",
     "    ax = df_.loc[:, [\"observed\", \"predicted\"]].plot(style=\".\", ax=ax)\n",
     "    y_max = df_.loc[:, [\"observed\", \"predicted\"]].values.max() * 0.8\n",
     "    p2 = ax.fill_between(\n",
@@ -296,22 +365,26 @@
    "cell_type": "code",
    "source": [
     "feature_col = target[0]\n",
-    "\n",
     "fig, ax = plt.subplots(ncols=1, figsize=(15, 5))\n",
-    "\n",
     "plot_obs_pred(\n",
     "    df=updated_features_testset,\n",
     "    feature=feature_col,\n",
     "    observed=feature_col,\n",
-    "    predicted=gamma_regressor.predict(updated_features_testset[training_variables]),\n",
+    "    predicted=gamma_regressor.predict(updated_features_testset[train_variables]),\n",
     "    y_label=\"Average claim severity\",\n",
     "    title=\"Predicted vs Observed\",\n",
     "    ax=ax\n",
     ")"
    ],
-   "id": "9e4d8078e3e989df",
+   "id": "1a6276ab8db8ed0d",
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "#TODO: Add more severity models (e.g., GBM with gamma loss), introduce mlflow\n",
+   "id": "d3726d90349f45ec"
   }
  ],
  "metadata": {


### PR DESCRIPTION
This pull request refactors and expands the `notebook/freq_sev/severity.ipynb` notebook to improve clarity, reproducibility, and modelling best practices for claim severity prediction. The changes provide a clearer workflow, enhance documentation, and update the modelling pipeline to use more standard scikit-learn approaches. The notebook now offers step-by-step explanations, improved evaluation, and better code organisation.

**Key improvements and changes:**

**1. Documentation and Workflow Clarity**
- Expanded markdown sections with overviews, step-by-step process tables, and rationale for modelling choices, making the notebook more accessible and easier to follow.

**2. Data Preparation and Feature Engineering**
- Replaced custom dataset and feature engineering code with standard pandas and scikit-learn workflows, including `train_test_split` and direct aggregation/merging of claims data.
- Updated feature engineering import to use the correct module path.

**3. Modelling Pipeline Updates**
- Clearly separated baseline (mean) and Gamma regression models, with improved code for model fitting and evaluation. 
- Addeda filtering step to ensure only positive claim severities are used for Gamma regression, matching statistical requirements.

**4. Evaluation and Visualisation Enhancements**
- Improved model evaluation function for clarity, returning and printing MSE and MAE, and updated model comparison logic for better readability. 

**5. Future Work**
- Added a TODO section suggesting the addition of advanced models (e.g., GBM with gamma loss) and mlflow integration for experiment tracking.