### PR TITLE
88 create config directory and yaml files for new and renewal clients

### DIFF
--- a/config/renewal.yaml
+++ b/config/renewal.yaml
@@ -1,0 +1,24 @@
+insurance_csv: "data/input/exp/Motor_vehicle_insurance_data.csv"
+
+features:
+  - Year_matriculation
+  - Type_risk
+  - Area
+  - Value_vehicle
+  - Distribution_channel
+  - Cylinder_capacity
+
+target: N_claims_year
+
+frequency:
+  algorithm: poisson_regressor
+  parameters:
+    alpha: 1.0
+    max_iter: 1000
+
+tracking:
+  uri: "http://127.0.0.1:5000"
+  experiment_name: "Insurance Claims Frequency Model"
+  run_name: "run_004"
+  run_description: "Poisson regression for insurance claims frequency prediction"
+  artifact_model_name: "poisson_model"

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,55 @@
+"""
+Pydantic schema for config/*.yaml files.
+
+Usage:
+    from src.config import load_config
+    config = load_config("config/renewal.yaml")   # returns a plain dict
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class FrequencyConfig(BaseModel):
+    algorithm: str
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("algorithm")
+    @classmethod
+    def algorithm_must_be_known(cls, v: str) -> str:
+        allowed = {"xgboost", "poisson_regressor", "gamma_regressor", "gradient_boosting"}
+        if v not in allowed:
+            raise ValueError(f"Unknown algorithm '{v}'. Choose from {sorted(allowed)}")
+        return v
+
+
+class TrackingConfig(BaseModel):
+    uri: str = "http://127.0.0.1:5000"
+    experiment_name: str
+    run_name: str = "run_001"
+    run_description: str = ""
+    artifact_model_name: str
+
+
+class RunConfig(BaseModel):
+    insurance_csv: str
+    features: list[str] = Field(min_length=1)
+    target: str
+    frequency: FrequencyConfig
+    tracking: TrackingConfig
+
+    @field_validator("insurance_csv")
+    @classmethod
+    def csv_path_must_exist(cls, v: str) -> str:
+        if not Path(v).exists():
+            raise ValueError(f"Data file not found: {v}")
+        return v
+
+
+def load_config(yaml_path: str) -> dict[str, Any]:
+    raw = yaml.safe_load(Path(yaml_path).read_text())
+    validated = RunConfig(**raw)
+    return validated.model_dump()


### PR DESCRIPTION
This pull request introduces a new configuration system for the insurance claims frequency modeling pipeline. It adds a YAML configuration file to define model parameters and a Pydantic-based schema for validating and loading these configurations in Python. The main focus is on making the configuration of model features, algorithms, and experiment tracking more structured and robust.

Configuration file addition:

* Added a new YAML file (`config/renewal.yaml`) to specify input data path, features, target variable, model algorithm (with parameters), and experiment tracking details for the insurance claims frequency model.

Configuration schema and validation:

* Introduced `src/config.py` containing Pydantic models (`FrequencyConfig`, `TrackingConfig`, `RunConfig`) to define and validate the structure of the YAML configuration, including checks for allowed algorithms and existence of the input CSV file.
* Provided a `load_config` function to load and validate the YAML configuration, returning a plain dictionary for downstream use.