### PR TITLE
Fix app Docker healthcheck endpoint

### DIFF
--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 RUN /usr/bin/apt-get update && \
-    /usr/bin/apt-get install -y --no-install-recommends gcc && \
+    /usr/bin/apt-get install -y --no-install-recommends curl gcc && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -13,6 +13,6 @@ COPY . /app/
 
 EXPOSE 80
 
-HEALTHCHECK --interval=30s --timeout=30s --start-period=10s CMD curl -f http://localhost:80/health || exit 1
+HEALTHCHECK --interval=30s --timeout=30s --start-period=10s CMD curl -f http://localhost:80/ready || exit 1
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -59,6 +59,7 @@ def predict(data: MotorInsuranceData):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+@app.get("/ready")
 @app.post("/ready")
 def readiness_checkpoint():
     logging.info("Readiness Checkpoint Ready")


### PR DESCRIPTION
## Summary
- install curl in the app image so the Docker HEALTHCHECK command can run
- point the healthcheck at the existing `/ready` endpoint instead of missing `/health`
- allow `/ready` to accept GET requests for Docker curl checks while keeping the existing POST route

Closes #106

## Validation
- `python3 -m py_compile src/app/main.py`
- `docker build -t underwriting-healthcheck-test ./src/app`
- `docker inspect underwriting-healthcheck-test --format='{{json .Config.Healthcheck.Test}}'` -> `["CMD-SHELL","curl -f http://localhost:80/ready || exit 1"]`
- `docker run --rm underwriting-healthcheck-test curl --version`
- `docker run --rm -i underwriting-healthcheck-test python - <<'PY' ...` verified `/ready` supports both `GET` and `POST`

Note: a full running-container healthy-state check still requires the app's model-loading env/artifact, because startup loads the MLflow model from S3 and `/ready` correctly fails until the model is loaded.