### PR TITLE
107 create missing new client yaml configuration file

### DIFF
--- a/config/new_client.yaml
+++ b/config/new_client.yaml
@@ -1,0 +1,24 @@
+insurance_csv: "data/input/exp/Motor_vehicle_insurance_data.csv"
+
+features:
+  - Year_matriculation
+  - Type_risk
+  - Area
+  - Value_vehicle
+  - Distribution_channel
+  - Cylinder_capacity
+
+target: N_claims_year
+
+frequency:
+  algorithm: poisson_regressor
+  parameters:
+    alpha: 1.0
+    max_iter: 1000
+
+tracking:
+  uri: "http://127.0.0.1:5000"
+  experiment_name: "Insurance Claims Frequency Model"
+  run_name: "run_new_client_001"
+  run_description: "Poisson regression for insurance claims frequency prediction"
+  artifact_model_name: "poisson_model"

--- a/src/config.py
+++ b/src/config.py
@@ -29,7 +29,7 @@ class FrequencyConfig(BaseModel):
 class TrackingConfig(BaseModel):
     uri: str = "http://127.0.0.1:5000"
     experiment_name: str
-    run_name: str = "run_001"
+    run_name: str = ""
     run_description: str = ""
     artifact_model_name: str
 


### PR DESCRIPTION
This pull request introduces a new configuration file for a client and makes a minor update to the default value for the `run_name` field in the tracking configuration. The main focus is on adding a YAML configuration for an insurance claims frequency prediction model, specifying data sources, features, target, modeling algorithm, and experiment tracking settings.

**New client configuration:**

* Added a new YAML file, `config/new_client.yaml`, defining the data source (`insurance_csv`), selected features, target variable, Poisson regression algorithm parameters, and MLflow tracking settings for an insurance claims frequency model.

**Configuration defaults update:**

* Changed the default value for `run_name` in the `TrackingConfig` class in `src/config.py` from `"run_001"` to an empty string, allowing explicit setting via configuration.