### PR TITLE
fix: add fit() to Vehicle transformer to prevent data leakage (#109)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas",
     "numpy",
     "scikit-learn",
+    "xgboost",
     "pypdf>=5.6.0",
     "docx2txt>=0.9",
     "unstructured",
@@ -36,6 +37,7 @@ build-backend = "hatchling.build"
 packages = ["src"]
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]

--- a/src/feature/vehicle.py
+++ b/src/feature/vehicle.py
@@ -7,8 +7,13 @@ from src.feature.base import BaseFeatureTransformer
 class Vehicle(BaseFeatureTransformer):
 
     def __init__(self):
-        ##kept here so that it can applied to test at some point using fit-transform?
-        self.fuel_type_uniques: pd.Index | None = None
+        self.fuel_type_uniques_: pd.Index | None = None
+
+    def fit(self, df: pd.DataFrame, source_col: str = "Type_fuel") -> "Vehicle":
+        # Learn the fuel-type -> code mapping ONCE, from training data only.
+        _, uniques = pd.factorize(df[source_col])
+        self.fuel_type_uniques_ = uniques
+        return self
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         df = self.encode_fuel_type(df)
@@ -20,10 +25,13 @@ class Vehicle(BaseFeatureTransformer):
             df: pd.DataFrame,
             source_col: str = "Type_fuel",
             column_to_be_created: str = "fuel_type_encoded") -> pd.DataFrame:
+        if self.fuel_type_uniques_ is None:
+            raise RuntimeError(
+                "Vehicle must be fitted before transform; call fit() first."
+            )
         df = df.copy()
-        codes, uniques = pd.factorize(df[source_col])
-        df[column_to_be_created] = codes
-        self.fuel_type_uniques = uniques
+        # Apply the LEARNED mapping. Unseen categories -> -1.
+        df[column_to_be_created] = self.fuel_type_uniques_.get_indexer(df[source_col])
         return df
 
     def log_transform_vehicle_value(

--- a/src/train/frequency.py
+++ b/src/train/frequency.py
@@ -17,7 +17,7 @@ def run(config):
     driver = Driver()
     vehicle = Vehicle()
 
-    trainset_feat = vehicle.transform(trainset)
+    trainset_feat = vehicle.fit(trainset).transform(trainset)
     trainset_feat = driver.transform(trainset_feat)
 
     testset_feat = vehicle.transform(testset)

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -21,6 +21,12 @@ def sample_df():
     })
 
 
+@pytest.fixture
+def fitted_vehicle(sample_df):
+    """A Vehicle that has learned its encoding from sample_df."""
+    return Vehicle().fit(sample_df)
+
+
 # =============================================================
 # 1. Instantiation
 # =============================================================
@@ -35,62 +41,127 @@ class TestVehicleInstantiation:
         assert isinstance(vehicle, Vehicle)
 
     def test_fuel_type_uniques_initially_none(self, vehicle):
-        assert vehicle.fuel_type_uniques is None
+        assert vehicle.fuel_type_uniques_ is None
 
 
 # =============================================================
-# 2. encode_fuel_type
+# 2. fit / transform contract (leakage prevention)
+# =============================================================
+
+class TestFitTransformContract:
+
+    def test_fit_returns_self(self, vehicle, sample_df):
+        assert vehicle.fit(sample_df) is vehicle
+
+    def test_fit_stores_fuel_type_uniques(self, vehicle, sample_df):
+        vehicle.fit(sample_df)
+        assert vehicle.fuel_type_uniques_ is not None
+        assert len(vehicle.fuel_type_uniques_) == sample_df["Type_fuel"].nunique()
+
+    def test_transform_before_fit_raises(self, vehicle, sample_df):
+        with pytest.raises(RuntimeError, match="fitted before transform"):
+            vehicle.transform(sample_df)
+
+    def test_encode_fuel_type_before_fit_raises(self, vehicle, sample_df):
+        with pytest.raises(RuntimeError, match="fitted before transform"):
+            vehicle.encode_fuel_type(sample_df)
+
+    def test_codes_consistent_across_reordered_data(self):
+        """The core leakage regression: a fuel type must map to the same code
+        on train and on a differently-ordered test set."""
+        train = pd.DataFrame({
+            "Type_fuel": ["Petrol", "Diesel", "LPG"],
+            "Value_vehicle": [10000.0, 20000.0, 30000.0],
+        })
+        # Test set with a different first-appearance order.
+        test = pd.DataFrame({
+            "Type_fuel": ["Diesel", "Petrol", "LPG"],
+            "Value_vehicle": [20000.0, 10000.0, 30000.0],
+        })
+
+        vehicle = Vehicle().fit(train)
+        train_encoded = vehicle.encode_fuel_type(train)
+        test_encoded = vehicle.encode_fuel_type(test)
+
+        train_map = dict(zip(train["Type_fuel"], train_encoded["fuel_type_encoded"]))
+        test_map = dict(zip(test["Type_fuel"], test_encoded["fuel_type_encoded"]))
+
+        assert train_map == test_map
+        assert train_map["Petrol"] == 0  # learned first -> always code 0
+
+    def test_fit_is_not_influenced_by_later_transform(self, vehicle, sample_df):
+        """transform() must not overwrite the learned mapping."""
+        vehicle.fit(sample_df)
+        before = vehicle.fuel_type_uniques_.copy()
+        other = pd.DataFrame({
+            "Type_fuel": ["Diesel", "LPG", "Petrol"],
+            "Value_vehicle": [1.0, 2.0, 3.0],
+        })
+        vehicle.encode_fuel_type(other)
+        pd.testing.assert_index_equal(vehicle.fuel_type_uniques_, before)
+
+    def test_unseen_category_maps_to_minus_one(self):
+        train = pd.DataFrame({
+            "Type_fuel": ["Petrol", "Diesel"],
+            "Value_vehicle": [10000.0, 20000.0],
+        })
+        test = pd.DataFrame({
+            "Type_fuel": ["Electric"],
+            "Value_vehicle": [40000.0],
+        })
+        vehicle = Vehicle().fit(train)
+        encoded = vehicle.encode_fuel_type(test)
+        assert encoded["fuel_type_encoded"].iloc[0] == -1
+
+
+# =============================================================
+# 3. encode_fuel_type
 # =============================================================
 
 class TestEncodeFuelType:
 
-    def test_creates_encoded_column(self, vehicle, sample_df):
-        result = vehicle.encode_fuel_type(sample_df)
+    def test_creates_encoded_column(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.encode_fuel_type(sample_df)
         assert "fuel_type_encoded" in result.columns
 
-    def test_encoded_values_are_integers(self, vehicle, sample_df):
-        result = vehicle.encode_fuel_type(sample_df)
+    def test_encoded_values_are_integers(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.encode_fuel_type(sample_df)
         assert pd.api.types.is_integer_dtype(result["fuel_type_encoded"])
 
-    def test_same_fuel_types_get_same_code(self, vehicle, sample_df):
-        result = vehicle.encode_fuel_type(sample_df)
+    def test_same_fuel_types_get_same_code(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.encode_fuel_type(sample_df)
         petrol_codes = result.loc[sample_df["Type_fuel"] == "Petrol", "fuel_type_encoded"]
         assert petrol_codes.nunique() == 1
 
-    def test_different_fuel_types_get_different_codes(self, vehicle, sample_df):
-        result = vehicle.encode_fuel_type(sample_df)
+    def test_different_fuel_types_get_different_codes(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.encode_fuel_type(sample_df)
         n_unique_types = sample_df["Type_fuel"].nunique()
         n_unique_codes = result["fuel_type_encoded"].nunique()
         assert n_unique_codes == n_unique_types
 
-    def test_stores_fuel_type_uniques(self, vehicle, sample_df):
-        vehicle.encode_fuel_type(sample_df)
-        assert vehicle.fuel_type_uniques is not None
-        assert len(vehicle.fuel_type_uniques) == sample_df["Type_fuel"].nunique()
-
-    def test_custom_column_name(self, vehicle, sample_df):
-        result = vehicle.encode_fuel_type(
+    def test_custom_column_name(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.encode_fuel_type(
             sample_df, column_to_be_created="custom_fuel"
         )
         assert "custom_fuel" in result.columns
         assert "fuel_type_encoded" not in result.columns
 
-    def test_does_not_mutate_original_dataframe(self, vehicle, sample_df):
+    def test_does_not_mutate_original_dataframe(self, fitted_vehicle, sample_df):
         original_columns = list(sample_df.columns)
-        _ = vehicle.encode_fuel_type(sample_df)
+        _ = fitted_vehicle.encode_fuel_type(sample_df)
         assert list(sample_df.columns) == original_columns
 
-    def test_returns_dataframe(self, vehicle, sample_df):
-        result = vehicle.encode_fuel_type(sample_df)
+    def test_returns_dataframe(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.encode_fuel_type(sample_df)
         assert isinstance(result, pd.DataFrame)
 
-    def test_non_fuel_columns_unchanged(self, vehicle, sample_df):
-        result = vehicle.encode_fuel_type(sample_df)
+    def test_non_fuel_columns_unchanged(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.encode_fuel_type(sample_df)
         pd.testing.assert_series_equal(result["N_doors"], sample_df["N_doors"])
 
 
 # =============================================================
-# 3. log_transform_vehicle_value
+# 4. log_transform_vehicle_value
 # =============================================================
 
 class TestLogTransformVehicleValue:
@@ -145,41 +216,36 @@ class TestLogTransformVehicleValue:
 
 
 # =============================================================
-# 4. transform (main entry point)
+# 5. transform (main entry point)
 # =============================================================
 
 class TestTransform:
 
-    def test_transform_creates_all_feature_columns(self, vehicle, sample_df):
-        result = vehicle.transform(sample_df)
+    def test_transform_creates_all_feature_columns(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.transform(sample_df)
         assert "fuel_type_encoded" in result.columns
         assert "Value_vehicle_log_transformed" in result.columns
 
-    def test_transform_returns_dataframe(self, vehicle, sample_df):
-        result = vehicle.transform(sample_df)
+    def test_transform_returns_dataframe(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.transform(sample_df)
         assert isinstance(result, pd.DataFrame)
 
-    def test_transform_does_not_mutate_original(self, vehicle, sample_df):
+    def test_transform_does_not_mutate_original(self, fitted_vehicle, sample_df):
         original_columns = list(sample_df.columns)
-        _ = vehicle.transform(sample_df)
+        _ = fitted_vehicle.transform(sample_df)
         assert list(sample_df.columns) == original_columns
 
-    def test_transform_preserves_non_transformed_columns(self, vehicle, sample_df):
-        result = vehicle.transform(sample_df)
+    def test_transform_preserves_non_transformed_columns(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.transform(sample_df)
         pd.testing.assert_series_equal(result["N_doors"], sample_df["N_doors"])
 
-    def test_transform_stores_fuel_type_uniques(self, vehicle, sample_df):
-        vehicle.transform(sample_df)
-        assert vehicle.fuel_type_uniques is not None
-
-    def test_transform_log_values_are_correct(self, vehicle, sample_df):
-        result = vehicle.transform(sample_df)
+    def test_transform_log_values_are_correct(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.transform(sample_df)
         expected = np.log(sample_df["Value_vehicle"])
         pd.testing.assert_series_equal(
             result["Value_vehicle_log_transformed"], expected, check_names=False
         )
 
-    def test_transform_encoded_values_match_unique_types(self, vehicle, sample_df):
-        result = vehicle.transform(sample_df)
+    def test_transform_encoded_values_match_unique_types(self, fitted_vehicle, sample_df):
+        result = fitted_vehicle.transform(sample_df)
         assert result["fuel_type_encoded"].nunique() == sample_df["Type_fuel"].nunique()
-

--- a/uv.lock
+++ b/uv.lock
@@ -4479,6 +4479,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8c/554bb020501d6c04ad8127d83f728137f8f9123f991666efbdcf9095a221/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:03ecd776fd1d58fd2c9a0a687dcf8db9ecd0057382dba646fa3d65786d4a9ea1", size = 303277471 },
+    { url = "https://files.pythonhosted.org/packages/50/32/e7ffa9c324ae260e5dbb4af2cd557bf7a8d155c8ac7b79a785fe1796fb92/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:8ce1b8213f61f2bfac132e6df890af6450b77cbd140c6ce4e98cb0c2d8e678c9", size = 303361239 },
+]
+
+[[package]]
 name = "olefile"
 version = "0.47"
 source = { registry = "https://pypi.org/simple" }
@@ -7471,6 +7480,9 @@ dependencies = [
     { name = "seaborn" },
     { name = "unstructured", version = "0.11.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "unstructured", version = "0.17.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "xgboost", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.optional-dependencies]
@@ -7501,6 +7513,7 @@ requires-dist = [
     { name = "scikit-learn" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "unstructured" },
+    { name = "xgboost" },
 ]
 provides-extras = ["test"]
 
@@ -7880,6 +7893,80 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/49/364a615a0cc0872685646c495c7172e4fc7bf1959e3b12a1807a03014e05/wrapt-1.17.2-cp39-cp39-win32.whl", hash = "sha256:f393cda562f79828f38a819f4788641ac7c4085f30f1ce1a68672baa686482bb", size = 36423 },
     { url = "https://files.pythonhosted.org/packages/00/ad/5d2c1b34ba3202cd833d9221833e74d6500ce66730974993a8dc9a94fb8c/wrapt-1.17.2-cp39-cp39-win_amd64.whl", hash = "sha256:36ccae62f64235cf8ddb682073a60519426fdd4725524ae38874adf72b5f2aeb", size = 38772 },
     { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594 },
+]
+
+[[package]]
+name = "xgboost"
+version = "2.1.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9.2' and python_full_version < '3.10'",
+    "python_full_version >= '3.9' and python_full_version < '3.9.2'",
+    "python_full_version < '3.9' and sys_platform != 'win32'",
+    "python_full_version < '3.9' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.10' and platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/5e/860a1ef13ce38db8c257c83e138be64bcffde8f401e84bf1e2e91838afa3/xgboost-2.1.4.tar.gz", hash = "sha256:ab84c4bbedd7fae1a26f61e9dd7897421d5b08454b51c6eb072abc1d346d08d7", size = 1091127 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/fe/7a1d2342c2e93f22b41515e02b73504c7809247b16ae395bd2ee7ef11e19/xgboost-2.1.4-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl", hash = "sha256:78d88da184562deff25c820d943420342014dd55e0f4c017cc4563c2148df5ee", size = 2140692 },
+    { url = "https://files.pythonhosted.org/packages/f5/b6/653a70910739f127adffbefb688ebc22b51139292757de7c22b1e04ce792/xgboost-2.1.4-py3-none-macosx_12_0_arm64.whl", hash = "sha256:523db01d4e74b05c61a985028bde88a4dd380eadc97209310621996d7d5d14a7", size = 1939418 },
+    { url = "https://files.pythonhosted.org/packages/43/06/905fee34c10fb0d0c3baa15106413b76f360d8e958765ec57c9eddf762fa/xgboost-2.1.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:57c7e98111aceef4b689d7d2ce738564a1f7fe44237136837a47847b8b33bade", size = 4442052 },
+    { url = "https://files.pythonhosted.org/packages/f8/6a/41956f91ab984f2fa44529b2551d825a20d33807eba051a60d06ede2a87c/xgboost-2.1.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1343a512e634822eab30d300bfc00bf777dc869d881cc74854b42173cfcdb14", size = 4533170 },
+    { url = "https://files.pythonhosted.org/packages/b1/53/37032dca20dae7a88ad1907f817a81f232ca6e935f0c28c98db3c0a0bd22/xgboost-2.1.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d366097d0db047315736f46af852feaa907f6d7371716af741cdce488ae36d20", size = 4206715 },
+    { url = "https://files.pythonhosted.org/packages/e4/3c/e3a93bfa7e8693c825df5ec02a40f7ff5f0950e02198b1e85da9315a8d47/xgboost-2.1.4-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8df6da72963969ab2bf49a520c3e147b1e15cbeddd3aa0e3e039b3532c739339", size = 223642416 },
+    { url = "https://files.pythonhosted.org/packages/43/80/0b5a2dfcf5b4da27b0b68d2833f05d77e1a374d43db951fca200a1f12a52/xgboost-2.1.4-py3-none-win_amd64.whl", hash = "sha256:8bbfe4fedc151b83a52edbf0de945fd94358b09a81998f2945ad330fd5f20cd6", size = 124910381 },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014 },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527 },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954 },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579 },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668 },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.12.4' and python_full_version < '3.13'",
+    "python_full_version >= '3.12' and python_full_version < '3.12.4'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/41/846d4de2b8fc694073fd3ac5052caf68caa1ea11cb7fa32d7ad9c049b232/xgboost-3.3.0.tar.gz", hash = "sha256:58bcb8a4cace648cdab7b94fa4f16d2c9ff26d90dd4d26907168106fa06d8746", size = 1224702 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/72/3b68983c0215ef65d48e9eeb1f168c3c6e3d62a61ece605de3209c79cae1/xgboost-3.3.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:07688a377046b8640897b62421150bf73c6cc7101823474ec6ad08b93290f587", size = 2553505 },
+    { url = "https://files.pythonhosted.org/packages/c9/62/b49e756822b29909d0c95ed334662dc6c7c81a99ec6bc10dc18e69f3d6e7/xgboost-3.3.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:af7cea10f418b7c251ddc8da440f57bdab2990b5fc9f74a35a92b0f150ea287d", size = 2376040 },
+    { url = "https://files.pythonhosted.org/packages/47/3a/a0adcd1ee28f525bd5c9dc3ebe78a7599bf97c22866d6449f967b829e338/xgboost-3.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:624a83aeb1e7ba081719795db179f4ce6fff12e79de05cd9baf15ee48fd22f0e", size = 98180629 },
+    { url = "https://files.pythonhosted.org/packages/47/1f/8b3e578cfd8e3bcdb4374e2bbe0b40b4e5320accb5cbdcf535ecc512eb5c/xgboost-3.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f59edaf28eccd1c519788607c72ed907ee6cedfa933d706620bc1612d24b354e", size = 98716607 },
+    { url = "https://files.pythonhosted.org/packages/07/6b/087fd5d28fdbb90d385c50ee9308a820241b82feebdf42e72e19a48e4b32/xgboost-3.3.0-py3-none-win_amd64.whl", hash = "sha256:b06057f6a018fc04e6b3e0c15568ca636b8151a5b5f333478e500fcaf4fc7594", size = 69522696 },
 ]
 
 [[package]]


### PR DESCRIPTION
Vehicle.transform() previously learned the fuel-type encoding via pd.factorize on every dataset it processed, so calling transform() on the test set re-derived (and overwrote) the mapping learned from train. This leaked test data into the encoding and made the integer codes inconsistent between train and test.

Split learning from applying using the sklearn fit/transform pattern:
- fit() learns the fuel-type -> code mapping once and stores it in fuel_type_uniques_
- transform()/encode_fuel_type() apply the stored mapping via pd.Index.get_indexer (unseen categories -> -1) and raise if called before fit()
- frequency.py now fits on the train set then transform-only on test

Also add a leakage regression test and make the full suite runnable (add xgboost dependency, set pytest pythonpath).