### PR TITLE
feat: add fit() to Driver transformer for consistency (#110)

### DIFF
--- a/src/feature/driver.py
+++ b/src/feature/driver.py
@@ -3,6 +3,9 @@ import pandas as pd
 from src.feature.base import BaseFeatureTransformer
 
 class Driver(BaseFeatureTransformer):
+    def fit(self, df: pd.DataFrame) -> "Driver":
+        return self
+
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         df = self.convert_all_date_columns_to_datetime(df)
         df = self.create_driver_age_at_contract_inception(df)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -347,3 +347,24 @@ class TestTransform:
         result = driver.transform(sample_df)
         assert (result["driver_experience_age"] >= 0).all()
 
+
+# =============================================================
+# 8. fit / transform contract (stateless)
+# =============================================================
+
+class TestFitTransformContract:
+
+    def test_fit_returns_self(self, driver, sample_df):
+        assert driver.fit(sample_df) is driver
+
+    def test_transform_works_without_fit(self, driver, sample_df):
+        """Driver is stateless: transform() does not require a prior fit()."""
+        result = driver.transform(sample_df)
+        assert isinstance(result, pd.DataFrame)
+
+    def test_fit_then_transform_chains(self, driver, sample_df):
+        """fit() is a no-op, so chaining produces the same columns as transform alone."""
+        chained = driver.fit(sample_df).transform(sample_df)
+        direct = Driver().transform(sample_df)
+        assert list(chained.columns) == list(direct.columns)
+


### PR DESCRIPTION
## Summary
Closes #110.

Adds a no-op `fit()` to the `Driver` transformer so it follows the same `fit().transform()` contract as `Vehicle`.

Unlike `Vehicle` (which learns a `pd.factorize` mapping in `fit()` and must guard `transform()` against leakage, per #109), `Driver` is **stateless** — every feature is a pure row-wise computation from date columns. So `fit()` simply returns `self`; no `__init__`, no `transform()` guard.

## Changes
- `src/feature/driver.py` — add `fit()` returning `self`, above `transform()` (mirrors `Vehicle` ordering).
- `tests/test_driver.py` — new `TestFitTransformContract`: `fit()` returns self, `transform()` works without a prior `fit()` (stateless contract), and `fit().transform()` yields the same columns as `transform()` alone.

## Verification
```
pytest -q   # 133 passed
```

